### PR TITLE
Custom factory method

### DIFF
--- a/JsonFx/JsonFx.Json.UnitTests/UnitTests/CustomFactoryTest.cs
+++ b/JsonFx/JsonFx.Json.UnitTests/UnitTests/CustomFactoryTest.cs
@@ -1,0 +1,92 @@
+using NUnit.Framework;
+
+namespace JsonFx.Json.Test.UnitTests
+{
+    [TestFixture]
+    public class CustomFactoryTest
+    {
+        public class MyFunnyType
+        {
+            [JsonIgnore]
+            public int hilarity;
+
+            public string setup;
+            public string punchline;
+
+            public MyFunnyType()
+            : this(1)
+            {
+            }
+
+            public MyFunnyType(int hilarity)
+            {
+                this.hilarity = hilarity;
+            }
+        }
+
+        public class MyContainedType
+        {
+            public MyFunnyType funny;
+        }
+        
+        [Test]
+        public void GivenNonDefaultConstructor_WhenDeserializeJson_ThenConstructorUsed()
+        {
+            var jsonString = "{\"setup\":\"When is a door not a door?\",\"punchline\":\"When it's ajar\"}";
+            var readerSettings = new JsonReaderSettings();
+            readerSettings.CreateInstance = t => t == typeof(MyFunnyType) ? new MyFunnyType(100) : null;
+            var joke = new JsonReader(jsonString, readerSettings).Deserialize<MyFunnyType>();
+            Assert.AreEqual(100, joke.hilarity);
+        }
+        
+        [Test]
+        public void GivenCreateInstanceReturnsNull_WhenDeserializeJson_ThenDefaultConstructorUsed()
+        {
+            var jsonString = "{\"setup\":\"What's brown and sticky?\",\"punchline\":\"a stick\"}";
+            var readerSettings = new JsonReaderSettings();
+            readerSettings.CreateInstance = t => null;
+
+            var joke = new JsonReader(jsonString, readerSettings).Deserialize<MyFunnyType>();
+            Assert.AreEqual(1, joke.hilarity);
+        }
+        
+        [Test]
+        public void GivenNoCreateInstance_WhenDeserializeJson_ThenDefaultConstructorUsed()
+        {
+            var jsonString = "{\"setup\":\"What's brown and sticky?\",\"punchline\":\"a stick\"}";
+            var readerSettings = new JsonReaderSettings();
+
+            var joke = new JsonReader(jsonString, readerSettings).Deserialize<MyFunnyType>();
+            Assert.AreEqual(1, joke.hilarity);
+        }
+        
+        [Test]
+        public void GivenNonDefaultConstructor_WhenDeserializeContainedJson_ThenConstructorUsed()
+        {
+            var jsonString = "{\"funny\":{\"setup\":\"When is a door not a door?\",\"punchline\":\"When it's ajar\"}}";
+            var readerSettings = new JsonReaderSettings();
+            readerSettings.CreateInstance = t => t == typeof(MyFunnyType) ? new MyFunnyType(100) : null;
+            var joke = new JsonReader(jsonString, readerSettings).Deserialize<MyContainedType>();
+            Assert.AreEqual(100, joke.funny.hilarity);
+        }
+        
+        [Test]
+        public void GivenCreateInstanceReturnsNull_WhenDeserializeContainedJson_ThenDefaultConstructorUsed()
+        {
+            var jsonString = "{\"funny\":{\"setup\":\"When is a door not a door?\",\"punchline\":\"When it's ajar\"}}";
+            var readerSettings = new JsonReaderSettings();
+            readerSettings.CreateInstance = t => null;
+            var joke = new JsonReader(jsonString, readerSettings).Deserialize<MyContainedType>();
+            Assert.AreEqual(1, joke.funny.hilarity);
+        }
+        
+        [Test]
+        public void GivenNoCreateInstance_WhenDeserializeContainedJson_ThenDefaultConstructorUsed()
+        {
+            var jsonString = "{\"funny\":{\"setup\":\"When is a door not a door?\",\"punchline\":\"When it's ajar\"}}";
+            var readerSettings = new JsonReaderSettings();
+            var joke = new JsonReader(jsonString, readerSettings).Deserialize<MyContainedType>();
+            Assert.AreEqual(1, joke.funny.hilarity);
+        }
+    }
+}

--- a/JsonFx/JsonFx.Json/JsonReaderSettings.cs
+++ b/JsonFx/JsonFx.Json/JsonReaderSettings.cs
@@ -88,6 +88,17 @@ namespace JsonFx.Json
 			set { this.typeHintAssembly = value; }
 		}
 
+		/// <summary>
+		/// Custom function that can be used as a factory method for creating instances of types as they are read in.
+		/// If you require custom constructor parameters, set this to create the deserialized objects.
+		/// If null is returned from this function, the default constructor will be used.
+		/// </summary>
+		public Func<Type, object> CreateInstance
+		{
+			get => Coercion.createInstance;
+			set => Coercion.createInstance = value;
+		}
+
 		#endregion Properties
 
 		#region Methods


### PR DESCRIPTION
## What?

Adding a function pointer in reader settings so that we can provide a custom factory method for instantiating types as they are deserialized. 

## Why?

In raksha, when deserializing JSON files, we want to be able to connect them to the correct root while being deserialized, instead of having a separate pass. Also, we can allocate types as we see fit, instead of just relying on Activator.

## Impact?

Only used if the setting field is set.

## Tests?

You betcha. There's automated tests. Dreamy.
